### PR TITLE
Fix children type for react-native-dialog

### DIFF
--- a/types/react-native-dialog/index.d.ts
+++ b/types/react-native-dialog/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for react-native-dialog 4.0
 // Project: https://github.com/mmazzarolo/react-native-dialog
 // Definitions by: MrLuje <https://github.com/MrLuje>
+//                 Stack Builders <https://github.com/stackbuilders>
+//                 Esteban <https://github.com/ibarrae>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -32,7 +34,7 @@ interface ButtonProps {
 
 interface ContainerProps {
     blurComponentIOS?: ReactNode;
-    children: JSX.Element[];
+    children: React.ReactNode[];
     /**
      * default: false
      */

--- a/types/react-native-dialog/index.d.ts
+++ b/types/react-native-dialog/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mmazzarolo/react-native-dialog
 // Definitions by: MrLuje <https://github.com/MrLuje>
 //                 Stack Builders <https://github.com/stackbuilders>
-//                 Esteban <https://github.com/ibarrae>
+//                 Esteban Ibarra <https://github.com/ibarrae>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-native-dialog/react-native-dialog-tests.tsx
+++ b/types/react-native-dialog/react-native-dialog-tests.tsx
@@ -16,6 +16,10 @@ class Example extends Component {
         );
     }
 
+    singleButton() {
+        return (<Dialog.Button label="Click" onPress={() => null} />);
+    }
+
     render() {
         const ref = createRef();
 
@@ -38,6 +42,7 @@ class Example extends Component {
                     onPress={() => console.log("test")}
                 />
                 {this.dynamicButtons()}
+                {this.singleButton()}
             </Dialog.Container>
         );
     }

--- a/types/react-native-dialog/react-native-dialog-tests.tsx
+++ b/types/react-native-dialog/react-native-dialog-tests.tsx
@@ -2,6 +2,20 @@ import Dialog from "react-native-dialog";
 import { createRef, Component } from "react";
 
 class Example extends Component {
+    dynamicButtons() {
+        const buttonFunc = () => console.log('click');
+        const buttons = [
+            { label: 'Button 1', action: buttonFunc },
+            { label: 'Button 2', action: buttonFunc },
+        ];
+        return buttons.map(({ label , action }) =>
+            <Dialog.Button
+                label={label}
+                onPress={action}
+            />
+        );
+    }
+
     render() {
         const ref = createRef();
 
@@ -23,6 +37,7 @@ class Example extends Component {
                     label="Validate"
                     onPress={() => console.log("test")}
                 />
+                {this.dynamicButtons()}
             </Dialog.Container>
         );
     }


### PR DESCRIPTION
Fix for allowing dynamic components inside of `Dialog.Container`.